### PR TITLE
Trim streamed history after final state

### DIFF
--- a/index.html
+++ b/index.html
@@ -702,6 +702,22 @@
             updateStatus();
         }
 
+        function finalizeStreamHistory(finalFen) {
+            if (!finalFen || !history.length) {
+                return;
+            }
+            const firstFinalIndex = history.indexOf(finalFen);
+            if (firstFinalIndex === -1) {
+                return;
+            }
+            const desiredLength = firstFinalIndex + 1;
+            if (history.length > desiredLength) {
+                history.splice(desiredLength);
+            }
+            historyIndex = history.length ? history.length - 1 : 0;
+            updateHistoryControls();
+        }
+
         function setColourSelection(value) {
             colourSelection = value;
             colourButtons.forEach(btn => {
@@ -808,6 +824,7 @@
                 };
                 sock.onclose = () => {
                     // after streaming, show next turn and start engine
+                    finalizeStreamHistory(chess.fen());
                     isStreaming = false;
                     updateStatus();
                     startGameEngine();


### PR DESCRIPTION
## Summary
- add logic to collapse the streamed history after the first occurrence of the final FEN
- call the new history finalizer when the WebSocket finishes streaming positions so navigation buttons reflect the canonical sequence

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68df9e96ce808323983d3934b45cf5e0