### PR TITLE
Add Google Tag Manager to site

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,13 @@
 <!DOCTYPE html><html lang="en">
 
 <head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-KDCV76T9');</script>
+    <!-- End Google Tag Manager -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>a chess thing i made</title>
@@ -496,6 +503,10 @@
 </head>
 
 <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KDCV76T9"
+            height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <div class="app-wrapper">
         <div class="brand">
             <img class="brand-logo" src="assets/logo.png" alt="ChessCrunch">


### PR DESCRIPTION
## Summary
- embed the Google Tag Manager script snippet in the document head
- add the noscript fallback iframe immediately after the body tag

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfa5b7751083238417b87a7f012a11