### PR TITLE
Refine in-game layout centering

### DIFF
--- a/index.html
+++ b/index.html
@@ -391,44 +391,57 @@
             display: none;
             width: 100%;
             min-height: 100dvh;
-            padding: clamp(1rem, 3vw, 2.5rem) clamp(1rem, 4vw, 2.5rem);
+            padding: clamp(0.5rem, 3vw, 2rem);
             box-sizing: border-box;
             flex-direction: column;
-            align-items: center;
-        }
-
-        .game-shell {
-            width: min(96vw, 1100px);
-            margin: 0 auto;
-            display: flex;
-            flex-direction: column;
-            gap: clamp(1rem, 3vw, 2.5rem);
-            min-height: 100%;
-            flex: 1 1 auto;
             align-items: stretch;
         }
 
-        .game-stage {
-            flex: 1 1 auto;
+        .game-shell {
+            width: 100%;
+            min-height: 100%;
+            margin: 0 auto;
+            display: grid;
+            grid-template-rows: auto minmax(0, 1fr) auto;
+            gap: clamp(1rem, 3vw, 2.5rem);
+            align-items: stretch;
+            justify-items: stretch;
+        }
+
+        .game-logo,
+        .game-board,
+        .game-controls {
+            width: 100%;
             display: flex;
-            flex-direction: column;
             align-items: center;
             justify-content: center;
-            gap: clamp(0.75rem, 3vw, 1.5rem);
-            margin: auto;
-            width: fit-content;
-            max-width: 100%;
+        }
+
+        .game-board {
+            min-width: 0;
+            min-height: 0;
+        }
+
+        .game-controls {
+            flex-direction: column;
+            gap: clamp(0.75rem, 3vw, 1.75rem);
+            text-align: center;
         }
 
         .board-shell {
             width: 100%;
             display: flex;
+            align-items: center;
             justify-content: center;
         }
 
         #board {
-            width: min(75vw, 75vh);
-            height: min(75vw, 75vh);
+            width: min(100vw, 100vh);
+            width: min(100vw, 100dvh);
+            height: min(100vw, 100vh);
+            height: min(100vw, 100dvh);
+            max-width: min(100vw, 100dvh);
+            max-height: min(100vw, 100dvh);
             margin: 0;
             /* Prevent scrolling/panning on mobile when dragging pieces */
             touch-action: none;
@@ -469,22 +482,6 @@
         }
 
         @media (max-width: 768px) {
-            body {
-                align-items: stretch;
-            }
-
-            #game {
-                padding: clamp(0.75rem, 3vw, 1.5rem) clamp(0.75rem, 4vw, 1.75rem);
-            }
-
-            .board-shell {
-                width: 100%;
-            }
-
-            #board {
-                margin: 0;
-            }
-
             #historyControls,
             #status,
             #streamingMessage {
@@ -495,13 +492,8 @@
 
         @media (orientation: landscape) {
             .game-shell {
-                flex-direction: row;
-                align-items: center;
-                justify-content: center;
-            }
-
-            .game-stage {
-                margin: auto;
+                grid-template-rows: minmax(0, 1fr);
+                grid-template-columns: auto minmax(0, 1fr) auto;
             }
 
             .brand--game {
@@ -514,8 +506,8 @@
         }
 
         @media (orientation: portrait) {
-            .game-stage {
-                width: 100%;
+            .game-shell {
+                grid-template-columns: 1fr;
             }
         }
 
@@ -663,16 +655,20 @@
 
     <div id="game">
         <div class="game-shell">
-            <div class="brand brand--game" id="inGameBrand" style="display: none;">
-                <picture>
-                    <source srcset="assets/chesscrush.com.svg" type="image/svg+xml">
-                    <img class="brand-logo" src="assets/chesscrush.com.png" alt="ChessCrush">
-                </picture>
+            <div class="game-logo">
+                <div class="brand brand--game" id="inGameBrand" style="display: none;">
+                    <picture>
+                        <source srcset="assets/chesscrush.com.svg" type="image/svg+xml">
+                        <img class="brand-logo" src="assets/chesscrush.com.png" alt="ChessCrush">
+                    </picture>
+                </div>
             </div>
-            <div class="game-stage">
+            <div class="game-board">
                 <div class="board-shell">
                     <div id="board" style="display: none;"></div>
                 </div>
+            </div>
+            <div class="game-controls">
                 <p id="streamingMessage" class="loading-message" style="display: none;">Streaming positions... please hang tight</p>
                 <div class="history-controls" id="historyControls" style="display: none;">
                     <button type="button" class="history-btn" id="historyPrev" aria-label="Previous move" disabled>

--- a/index.html
+++ b/index.html
@@ -51,28 +51,36 @@
 
         .setup-shell {
             width: 100vw;
-            min-height: 100dvh;
+            height: 100dvh;
             display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            gap: clamp(1.5rem, 4vw, 3rem);
-            padding: clamp(1.5rem, 4vw, 3.5rem);
-            box-sizing: border-box;
+            flex-direction: row;
         }
 
         .setup-logo,
-        .setup-main {
+        .setup-main,
+        .setup-filler {
+            flex: 1 1 0;
             display: flex;
             align-items: center;
             justify-content: center;
-            width: 100%;
+            min-width: 0;
+            min-height: 0;
         }
 
         .setup-main {
+            flex: 0 0 auto;
+            width: min(90vw, 560px);
+            max-width: min(90vw, 560px);
+            padding: clamp(1.5rem, 4vw, 3.5rem);
+            box-sizing: border-box;
             flex-direction: column;
             gap: clamp(1.25rem, 4vw, 2.75rem);
-            width: min(90vw, 560px);
+            align-items: center;
+            justify-content: center;
+        }
+
+        .setup-logo {
+            padding: clamp(1.5rem, 4vw, 3.5rem);
         }
 
         .brand {
@@ -111,24 +119,19 @@
             }
         }
 
-        @media (orientation: landscape) {
+        @media (orientation: portrait) {
             .setup-shell {
-                flex-direction: row;
-                align-items: stretch;
+                flex-direction: column;
             }
 
             .setup-logo,
-            .setup-main {
-                height: 100%;
-            }
-
-            .setup-logo {
-                flex: 1 1 0;
+            .setup-filler {
+                padding: clamp(1.5rem, 6vw, 4rem);
             }
 
             .setup-main {
-                width: min(55vw, 560px);
-                flex: 0 1 auto;
+                width: min(92vw, 560px);
+                max-width: min(92vw, 560px);
             }
         }
 
@@ -698,6 +701,7 @@
                 <button id="generateBtn" class="start-button">Start Game</button>
             </div>
         </div>
+        <div class="setup-filler" aria-hidden="true"></div>
     </div>
     <!-- Error modal -->
     <div class="modal" id="errorModal">

--- a/index.html
+++ b/index.html
@@ -45,30 +45,40 @@
             margin: 0;
             min-height: 100vh;
             min-height: 100dvh;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
             color: var(--text);
             overflow-x: hidden;
         }
 
-        .app-wrapper {
-            width: min(90vw, 560px);
-            margin: 0 auto 1.5rem;
+        .setup-shell {
+            width: 100vw;
+            min-height: 100dvh;
             display: flex;
             flex-direction: column;
             align-items: center;
-            gap: 1rem;
+            justify-content: center;
+            gap: clamp(1.5rem, 4vw, 3rem);
+            padding: clamp(1.5rem, 4vw, 3.5rem);
+            box-sizing: border-box;
+        }
+
+        .setup-logo,
+        .setup-main {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 100%;
+        }
+
+        .setup-main {
+            flex-direction: column;
+            gap: clamp(1.25rem, 4vw, 2.75rem);
+            width: min(90vw, 560px);
         }
 
         .brand {
             display: flex;
             justify-content: center;
             margin: 0.02rem 0;
-        }
-
-        .app-wrapper > .brand {
-            align-self: center;
         }
 
         .brand-logo {
@@ -98,6 +108,27 @@
         @media (max-width: 600px) {
             h1 {
                 display: none;
+            }
+        }
+
+        @media (orientation: landscape) {
+            .setup-shell {
+                flex-direction: row;
+                align-items: stretch;
+            }
+
+            .setup-logo,
+            .setup-main {
+                height: 100%;
+            }
+
+            .setup-logo {
+                flex: 1 1 0;
+            }
+
+            .setup-main {
+                width: min(55vw, 560px);
+                flex: 0 1 auto;
             }
         }
 
@@ -587,34 +618,37 @@
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KDCV76T9"
             height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
-    <div class="app-wrapper">
-        <div class="brand">
-            <picture>
-                <source srcset="assets/chesscrush.com.svg" type="image/svg+xml">
-                <img class="brand-logo" src="assets/chesscrush.com.png" alt="ChessCrush">
-            </picture>
+    <div class="setup-shell" id="setup">
+        <div class="setup-logo">
+            <div class="brand">
+                <picture>
+                    <source srcset="assets/chesscrush.com.svg" type="image/svg+xml">
+                    <img class="brand-logo" src="assets/chesscrush.com.png" alt="ChessCrush">
+                </picture>
+            </div>
         </div>
-        <h1>Game Setup</h1>
+        <div class="setup-main">
+            <h1>Game Setup</h1>
 
-        <div class="setup-card">
-            <div class="controls">
-                <div class="control-group">
-                    <label for="playerColourRandom">Colour</label>
-                    <div class="colour-choice-grid" role="radiogroup" aria-label="Choose your side">
-                        <button type="button" class="colour-choice" data-value="white" aria-pressed="false">
-                            <img src="assets/white.png" alt="Play as white">
-                            <span>White</span>
-                        </button>
-                        <button type="button" class="colour-choice active" data-value="random" id="playerColourRandom" aria-pressed="true">
-                            <img src="assets/random.png" alt="Random side icon">
-                            <span>Random</span>
-                        </button>
-                        <button type="button" class="colour-choice" data-value="black" aria-pressed="false">
-                            <img src="assets/black.png" alt="Play as black">
-                            <span>Black</span>
-                        </button>
+            <div class="setup-card">
+                <div class="controls">
+                    <div class="control-group">
+                        <label for="playerColourRandom">Colour</label>
+                        <div class="colour-choice-grid" role="radiogroup" aria-label="Choose your side">
+                            <button type="button" class="colour-choice" data-value="white" aria-pressed="false">
+                                <img src="assets/white.png" alt="Play as white">
+                                <span>White</span>
+                            </button>
+                            <button type="button" class="colour-choice active" data-value="random" id="playerColourRandom" aria-pressed="true">
+                                <img src="assets/random.png" alt="Random side icon">
+                                <span>Random</span>
+                            </button>
+                            <button type="button" class="colour-choice" data-value="black" aria-pressed="false">
+                                <img src="assets/black.png" alt="Play as black">
+                                <span>Black</span>
+                            </button>
+                        </div>
                     </div>
-                </div>
 
                 <div class="control-group">
                     <label for="advantage">Starting position</label>
@@ -659,9 +693,10 @@
                     <input type="hidden" id="minPlies" value="16">
                     <input type="hidden" id="maxPlies" value="60">
                 </div>
-            </div>
+                </div>
 
-            <button id="generateBtn" class="start-button">Start Game</button>
+                <button id="generateBtn" class="start-button">Start Game</button>
+            </div>
         </div>
     </div>
     <!-- Error modal -->
@@ -890,7 +925,7 @@
             resetHistory(chess.fen());
 
             // hide controls container and show board
-            const setupWrapper = document.querySelector('.app-wrapper');
+            const setupWrapper = document.querySelector('.setup-shell');
             if (setupWrapper) setupWrapper.style.display = 'none';
             const gameShell = document.getElementById('game');
             if (gameShell) gameShell.style.display = 'flex';

--- a/index.html
+++ b/index.html
@@ -398,14 +398,16 @@
         }
 
         .game-shell {
+            --board-size: min(100vw, 100dvh);
             width: 100%;
             min-height: 100%;
             margin: 0 auto;
             display: grid;
-            grid-template-rows: auto minmax(0, 1fr) auto;
             gap: clamp(1rem, 3vw, 2.5rem);
-            align-items: stretch;
-            justify-items: stretch;
+            align-items: center;
+            justify-items: center;
+            grid-template-columns: minmax(0, 1fr);
+            grid-template-rows: max(0px, calc((100dvh - var(--board-size)) / 2)) minmax(0, var(--board-size)) max(0px, calc((100dvh - var(--board-size)) / 2));
         }
 
         .game-logo,
@@ -424,8 +426,10 @@
 
         .game-controls {
             flex-direction: column;
+            justify-content: center;
             gap: clamp(0.75rem, 3vw, 1.75rem);
             text-align: center;
+            max-width: 100%;
         }
 
         .board-shell {
@@ -436,12 +440,10 @@
         }
 
         #board {
-            width: min(100vw, 100vh);
-            width: min(100vw, 100dvh);
-            height: min(100vw, 100vh);
-            height: min(100vw, 100dvh);
-            max-width: min(100vw, 100dvh);
-            max-height: min(100vw, 100dvh);
+            width: var(--board-size);
+            height: var(--board-size);
+            max-width: var(--board-size);
+            max-height: var(--board-size);
             margin: 0;
             /* Prevent scrolling/panning on mobile when dragging pieces */
             touch-action: none;
@@ -493,7 +495,14 @@
         @media (orientation: landscape) {
             .game-shell {
                 grid-template-rows: minmax(0, 1fr);
-                grid-template-columns: auto minmax(0, 1fr) auto;
+                grid-template-columns: max(0px, calc((100vw - var(--board-size)) / 2)) minmax(0, var(--board-size)) max(0px, calc((100vw - var(--board-size)) / 2));
+            }
+
+            .game-logo,
+            .game-controls {
+                min-width: max(0px, calc((100vw - var(--board-size)) / 2));
+                max-width: max(0px, calc((100vw - var(--board-size)) / 2));
+                height: 100%;
             }
 
             .brand--game {
@@ -507,13 +516,21 @@
 
         @media (orientation: portrait) {
             .game-shell {
-                grid-template-columns: 1fr;
+                grid-template-columns: minmax(0, 1fr);
+            }
+
+            .game-logo,
+            .game-controls {
+                min-height: max(0px, calc((100dvh - var(--board-size)) / 2));
+                max-height: max(0px, calc((100dvh - var(--board-size)) / 2));
+                width: 100%;
             }
         }
 
         #status {
             font-size: 1.125rem;
             text-align: center;
+            overflow-wrap: anywhere;
         }
         .modal {
             display: none;

--- a/index.html
+++ b/index.html
@@ -121,6 +121,7 @@
             .setup-shell {
                 justify-content: center;
                 align-items: center;
+                padding-top: clamp(1.5rem, 8vw, 3rem);
             }
 
             .setup-logo,

--- a/index.html
+++ b/index.html
@@ -83,6 +83,10 @@
             padding: clamp(1.5rem, 4vw, 3.5rem);
         }
 
+        .setup-filler {
+            padding: clamp(1.5rem, 4vw, 3.5rem);
+        }
+
         .brand {
             display: flex;
             justify-content: center;

--- a/index.html
+++ b/index.html
@@ -132,6 +132,11 @@
             h1 {
                 display: none;
             }
+
+            .setup-main {
+                width: 100vw;
+                max-width: 100vw;
+            }
         }
 
         @media (orientation: portrait) {
@@ -143,7 +148,9 @@
             .setup-filler {
                 padding: clamp(1.5rem, 6vw, 4rem);
             }
+        }
 
+        @media (orientation: portrait) and (min-width: 901px) {
             .setup-main {
                 width: min(92vw, 560px);
                 max-width: min(92vw, 560px);

--- a/index.html
+++ b/index.html
@@ -405,14 +405,19 @@
             gap: clamp(1rem, 3vw, 2.5rem);
             min-height: 100%;
             flex: 1 1 auto;
+            align-items: stretch;
         }
 
         .game-stage {
+            flex: 1 1 auto;
             display: flex;
             flex-direction: column;
             align-items: center;
+            justify-content: center;
             gap: clamp(0.75rem, 3vw, 1.5rem);
-            margin-block: auto;
+            margin: auto;
+            width: fit-content;
+            max-width: 100%;
         }
 
         .board-shell {
@@ -491,12 +496,11 @@
         @media (orientation: landscape) {
             .game-shell {
                 flex-direction: row;
-                align-items: stretch;
+                align-items: center;
                 justify-content: center;
             }
 
             .game-stage {
-                flex: 1 1 auto;
                 margin: auto;
             }
 

--- a/index.html
+++ b/index.html
@@ -117,7 +117,17 @@
             text-align: center;
         }
 
-        @media (max-width: 600px) {
+        @media (max-width: 900px) {
+            .setup-shell {
+                justify-content: center;
+                align-items: center;
+            }
+
+            .setup-logo,
+            .setup-filler {
+                display: none;
+            }
+
             h1 {
                 display: none;
             }
@@ -525,9 +535,8 @@
             border: 3px solid rgba(64, 64, 64, 0.85);
         }
 
-        @media (max-width: 768px) {
+        @media (max-width: 900px) {
             #historyControls,
-            #status,
             #streamingMessage {
                 padding: 0 clamp(0.75rem, 4vw, 1.5rem);
                 text-align: center;
@@ -568,9 +577,28 @@
         }
 
         #status {
-            font-size: 1.125rem;
+            margin: 0;
+            padding: 1rem 1.5rem;
+            max-width: min(28rem, 82vw);
+            border: 2px solid rgba(20, 20, 20, 0.2);
+            border-radius: 16px;
+            background: linear-gradient(180deg, rgba(255, 255, 255, 0.95) 0%, rgba(230, 230, 230, 0.9) 100%);
+            box-shadow: 0 18px 38px rgba(0, 0, 0, 0.12);
+            font-size: clamp(1rem, 2.4vw, 1.25rem);
+            font-weight: 600;
+            letter-spacing: 0.04em;
+            line-height: 1.6;
             text-align: center;
+            color: var(--heading);
             overflow-wrap: anywhere;
+            text-wrap: balance;
+        }
+
+        @media (max-width: 900px) {
+            #status {
+                padding: clamp(0.85rem, 4vw, 1.25rem) clamp(0.9rem, 5vw, 1.6rem);
+                max-width: min(24rem, 90vw);
+            }
         }
         .modal {
             display: none;

--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
             background: var(--bg);
             margin: 0;
             min-height: 100vh;
+            min-height: 100dvh;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -61,16 +62,30 @@
         }
 
         .brand {
-            align-self: center;
             display: flex;
             justify-content: center;
             margin: 0.02rem 0;
         }
 
+        .app-wrapper > .brand {
+            align-self: center;
+        }
+
         .brand-logo {
-            width: clamp(180px, 44vw, 240px);
+            width: clamp(190px, 48vw, 320px);
             height: auto;
             display: block;
+        }
+
+        .brand--game {
+            display: none;
+            flex: 1 1 0;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .brand--game .brand-logo {
+            width: clamp(150px, 32vw, 240px);
         }
 
         h1 {
@@ -374,11 +389,36 @@
 
         #game {
             display: none;
-            width: min(90vw, 560px);
-            margin: 0 auto 1.5rem;
+            width: 100%;
+            min-height: 100dvh;
+            padding: clamp(1rem, 3vw, 2.5rem) clamp(1rem, 4vw, 2.5rem);
+            box-sizing: border-box;
             flex-direction: column;
             align-items: center;
-            gap: 1rem;
+        }
+
+        .game-shell {
+            width: min(96vw, 1100px);
+            margin: 0 auto;
+            display: flex;
+            flex-direction: column;
+            gap: clamp(1rem, 3vw, 2.5rem);
+            min-height: 100%;
+            flex: 1 1 auto;
+        }
+
+        .game-stage {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: clamp(0.75rem, 3vw, 1.5rem);
+            margin-block: auto;
+        }
+
+        .board-shell {
+            width: 100%;
+            display: flex;
+            justify-content: center;
         }
 
         #board {
@@ -429,15 +469,11 @@
             }
 
             #game {
-                width: 100vw;
-                margin: 0;
-                padding: 0;
-                padding-bottom: clamp(0.75rem, 3vw, 1.25rem);
-                min-height: 100vh;
-                display: flex;
-                flex-direction: column;
-                align-items: center;
-                gap: clamp(0.75rem, 3vw, 1.25rem);
+                padding: clamp(0.75rem, 3vw, 1.5rem) clamp(0.75rem, 4vw, 1.75rem);
+            }
+
+            .board-shell {
+                width: 100%;
             }
 
             #board {
@@ -449,6 +485,33 @@
             #streamingMessage {
                 padding: 0 clamp(0.75rem, 4vw, 1.5rem);
                 text-align: center;
+            }
+        }
+
+        @media (orientation: landscape) {
+            .game-shell {
+                flex-direction: row;
+                align-items: stretch;
+                justify-content: center;
+            }
+
+            .game-stage {
+                flex: 1 1 auto;
+                margin: auto;
+            }
+
+            .brand--game {
+                max-width: clamp(160px, 22vw, 260px);
+            }
+
+            .brand--game .brand-logo {
+                width: clamp(140px, 18vw, 220px);
+            }
+        }
+
+        @media (orientation: portrait) {
+            .game-stage {
+                width: 100%;
             }
         }
 
@@ -511,7 +574,10 @@
     <!-- End Google Tag Manager (noscript) -->
     <div class="app-wrapper">
         <div class="brand">
-            <img class="brand-logo" src="assets/logo.png" alt="ChessCrunch">
+            <picture>
+                <source srcset="assets/chesscrush.com.svg" type="image/svg+xml">
+                <img class="brand-logo" src="assets/chesscrush.com.png" alt="ChessCrush">
+            </picture>
         </div>
         <h1>Game Setup</h1>
 
@@ -592,21 +658,30 @@
     </div>
 
     <div id="game">
-        <div class="brand" id="inGameBrand" style="display: none;">
-            <img class="brand-logo" src="assets/logo.png" alt="ChessCrunch">
+        <div class="game-shell">
+            <div class="brand brand--game" id="inGameBrand" style="display: none;">
+                <picture>
+                    <source srcset="assets/chesscrush.com.svg" type="image/svg+xml">
+                    <img class="brand-logo" src="assets/chesscrush.com.png" alt="ChessCrush">
+                </picture>
+            </div>
+            <div class="game-stage">
+                <div class="board-shell">
+                    <div id="board" style="display: none;"></div>
+                </div>
+                <p id="streamingMessage" class="loading-message" style="display: none;">Streaming positions... please hang tight</p>
+                <div class="history-controls" id="historyControls" style="display: none;">
+                    <button type="button" class="history-btn" id="historyPrev" aria-label="Previous move" disabled>
+                        <span aria-hidden="true">←</span>
+                    </button>
+                    <span class="history-indicator" id="historyIndicator">Move 0 / 0</span>
+                    <button type="button" class="history-btn" id="historyNext" aria-label="Next move" disabled>
+                        <span aria-hidden="true">→</span>
+                    </button>
+                </div>
+                <p id="status" style="display: none;"></p>
+            </div>
         </div>
-        <div id="board" style="display: none;"></div>
-        <p id="streamingMessage" class="loading-message" style="display: none;">Streaming positions... please hang tight</p>
-        <div class="history-controls" id="historyControls" style="display: none;">
-            <button type="button" class="history-btn" id="historyPrev" aria-label="Previous move" disabled>
-                <span aria-hidden="true">←</span>
-            </button>
-            <span class="history-indicator" id="historyIndicator">Move 0 / 0</span>
-            <button type="button" class="history-btn" id="historyNext" aria-label="Next move" disabled>
-                <span aria-hidden="true">→</span>
-            </button>
-        </div>
-        <p id="status" style="display: none;"></p>
     </div>
 
     <script>

--- a/index.html
+++ b/index.html
@@ -389,23 +389,25 @@
 
         #game {
             display: none;
-            width: 100%;
-            min-height: 100dvh;
-            padding: clamp(0.5rem, 3vw, 2rem);
+            width: 100vw;
+            height: 100dvh;
+            margin: 0;
+            padding: 0;
             box-sizing: border-box;
             flex-direction: column;
-            align-items: stretch;
+            align-items: center;
+            justify-content: center;
+            overflow: hidden;
         }
 
         .game-shell {
             --board-size: min(100vw, 100dvh);
-            width: 100%;
-            min-height: 100%;
-            margin: 0 auto;
+            width: 100vw;
+            height: 100dvh;
             display: grid;
-            gap: clamp(1rem, 3vw, 2.5rem);
-            align-items: center;
-            justify-items: center;
+            gap: 0;
+            align-items: stretch;
+            justify-items: stretch;
             grid-template-columns: minmax(0, 1fr);
             grid-template-rows: max(0px, calc((100dvh - var(--board-size)) / 2)) minmax(0, var(--board-size)) max(0px, calc((100dvh - var(--board-size)) / 2));
         }
@@ -413,27 +415,29 @@
         .game-logo,
         .game-board,
         .game-controls {
-            width: 100%;
             display: flex;
             align-items: center;
             justify-content: center;
-        }
-
-        .game-board {
             min-width: 0;
             min-height: 0;
         }
 
+        .game-logo {
+            flex-direction: column;
+            text-align: center;
+        }
+
         .game-controls {
             flex-direction: column;
-            justify-content: center;
             gap: clamp(0.75rem, 3vw, 1.75rem);
             text-align: center;
-            max-width: 100%;
+            width: 100%;
+            height: 100%;
         }
 
         .board-shell {
-            width: 100%;
+            width: var(--board-size);
+            height: var(--board-size);
             display: flex;
             align-items: center;
             justify-content: center;
@@ -494,14 +498,13 @@
 
         @media (orientation: landscape) {
             .game-shell {
-                grid-template-rows: minmax(0, 1fr);
+                grid-template-rows: minmax(0, var(--board-size));
                 grid-template-columns: max(0px, calc((100vw - var(--board-size)) / 2)) minmax(0, var(--board-size)) max(0px, calc((100vw - var(--board-size)) / 2));
             }
 
             .game-logo,
             .game-controls {
-                min-width: max(0px, calc((100vw - var(--board-size)) / 2));
-                max-width: max(0px, calc((100vw - var(--board-size)) / 2));
+                width: 100%;
                 height: 100%;
             }
 
@@ -521,9 +524,8 @@
 
             .game-logo,
             .game-controls {
-                min-height: max(0px, calc((100dvh - var(--board-size)) / 2));
-                max-height: max(0px, calc((100dvh - var(--board-size)) / 2));
                 width: 100%;
+                height: 100%;
             }
         }
 


### PR DESCRIPTION
## Summary
- restructure the in-game markup so the logo wrapper and game stack occupy a two-panel layout
- center the board, history controls, and status vertically with orientation-specific flex rules
- adjust responsive styling so the board sizing uses viewport constraints while the logo centers within its space

## Testing
- Manual verification via `python3 -m http.server 8000` and Playwright-driven viewport checks

------
https://chatgpt.com/codex/tasks/task_e_68dfb1609c00832399dca7fba6dc9dea